### PR TITLE
docs: update Node.js version prerequisite to >=20

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It showcases several embedding techniques, such as:
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org)
+- [Node.js](https://nodejs.org) version 20 or higher
 - An [OAuth M2M client](https://qlik.dev/authenticate/oauth/create/create-oauth-client/) for the backend calls, configured with:
     - Scopes: `user_default`, `admin_classic`
     - Allowed origins: `http://localhost:3000`


### PR DESCRIPTION
This pull request updates Node.js version prerequisite to >=20 to match `@qlik/api` requirements (since v.1.29.0).
[DOC-1702](https://qlik-dev.atlassian.net/browse/DOC-1702)